### PR TITLE
Bump version to 1.4.1 and update uploads

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,13 +1,29 @@
-import groovy.json.JsonSlurper
-
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 // Read version from package.json
 def getVersionFromPackageJson() {
-    def packageJson = new JsonSlurper().parse(file("../../package.json"))
-    return packageJson.version
+    def packageJsonText = file("../../package.json").getText("UTF-8")
+    def versionMatcher = (packageJsonText =~ /"version"\s*:\s*"([^"]+)"/)
+    if (versionMatcher.find()) {
+        return versionMatcher.group(1)
+    }
+    return "1.0.0"
+}
+
+// Convert semver (major.minor.patch) to monotonic Android versionCode.
+// Example: 1.4.1 -> 10401
+def getVersionCodeFromPackageJson() {
+    def version = getVersionFromPackageJson()
+    def numericPart = version.tokenize('-')[0]
+    def parts = numericPart.tokenize('.')
+
+    int major = parts.size() > 0 ? parts[0].toInteger() : 1
+    int minor = parts.size() > 1 ? parts[1].toInteger() : 0
+    int patch = parts.size() > 2 ? parts[2].toInteger() : 0
+
+    return major * 10000 + minor * 100 + patch
 }
 
 /**
@@ -90,7 +106,7 @@ android {
         applicationId "com.flickv4"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
+        versionCode getVersionCodeFromPackageJson()
         versionName getVersionFromPackageJson()
     }
     signingConfigs {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -29,7 +29,7 @@ android.useAndroidX=true
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-reactNativeArchitectures=arm64-v8a
+reactNativeArchitectures=arm64-v8a,armeabi-v7a
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Flickv4",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "private": true,
   "scripts": {
     "clean:android": "cd android && ./gradlew clean",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "Flickv4",
-  "version": "1.4.2",
+  "version": "1.4.1",
   "private": true,
   "scripts": {
     "clean:android": "cd android && ./gradlew clean",
     "android": "react-native run-android",
     "build:android": "react-native run-android --mode=release",
+    "assemble:android": "cd android && ./gradlew clean && ./gradlew assembleRelease",
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start --reset-cache",


### PR DESCRIPTION
This pull request updates the version number in the `package.json` file to reflect a new release.

Versioning:

* Updated the `version` field in `package.json` from `1.4.0` to `1.4.2` to indicate a new release.
This pull request introduces improvements to the Android build process and configuration, as well as a minor version bump and a new build script. The most significant changes include automating the Android `versionCode` based on the `package.json` version, expanding supported architectures, and adding a new build script for Android releases.

**Android build and versioning improvements:**

* Replaced the use of `JsonSlurper` in `android/app/build.gradle` with a regex-based approach to extract the version from `package.json`, and added a new function to convert semantic versioning into a monotonic Android `versionCode` (e.g., 1.4.1 → 10401). This ensures that the Android `versionCode` automatically matches the app version.
* Updated the `defaultConfig` in `android/app/build.gradle` to set `versionCode` using the new function, so it always reflects the `package.json` version.

**Build configuration:**

* Expanded the supported Android architectures in `android/gradle.properties` to include both `arm64-v8a` and `armeabi-v7a` for broader device compatibility.

**Scripts and version bump:**

* Added a new npm script `assemble:android` to automate cleaning and assembling the Android release build.
* Bumped the app version in `package.json` from `1.4.0` to `1.4.1`.