### PR TITLE
refactor: migrate from expo-video to react-native-video for enhanced playback features

### DIFF
--- a/app.json
+++ b/app.json
@@ -34,10 +34,10 @@
     },
     "plugins": [
       [
-        "expo-video",
+        "react-native-video",
         {
-          "supportsBackgroundPlayback": true,
-          "supportsPictureInPicture": true
+          "enableBackgroundAudio": true,
+          "enableAndroidPictureInPicture": true
         }
       ],
       [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flick",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flick",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "dependencies": {
         "@expo/html-elements": "^0.12.5",
         "@gluestack-ui/core": "^5.0.15",
@@ -29,7 +29,6 @@
         "expo-notifications": "~57.0.6",
         "expo-screen-orientation": "~57.0.1",
         "expo-status-bar": "~57.0.1",
-        "expo-video": "~57.0.1",
         "lucide-react-native": "^1.25.0",
         "nativewind": "^5.0.0-preview.2",
         "react": "19.2.3",
@@ -42,6 +41,7 @@
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
         "react-native-svg": "15.15.4",
+        "react-native-video": "^6.19.2",
         "react-native-webview": "^13.16.0",
         "react-native-worklets": "0.10.0",
         "react-native-youtube-iframe": "^2.4.1",
@@ -5189,17 +5189,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-video": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-video/-/expo-video-57.0.1.tgz",
-      "integrity": "sha512-tNp5AHFq40q+b6BvzpAPnLBdZKdIto+mQcgl9HpWFFLUjaQc4adqvKPMPOsDPSx6MrebITdbsinHaaAdVzdXZg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo/node_modules/@expo/cli": {
       "version": "57.0.9",
       "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-57.0.9.tgz",
@@ -7837,6 +7826,16 @@
         "css-tree": "^1.1.3",
         "warn-once": "0.1.1"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-video": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/react-native-video/-/react-native-video-6.19.2.tgz",
+      "integrity": "sha512-gh5dBMGSHywKr8+p4azRXrFQgT+QTmS1tI4sz6kVRjSENORfsrGGLQzmyo/7S9m+ZOTLWQJ3h8ONaXxR4F2Fcw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flick",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "index.ts",
   "dependencies": {
     "@expo/html-elements": "^0.12.5",
@@ -24,7 +24,6 @@
     "expo-notifications": "~57.0.6",
     "expo-screen-orientation": "~57.0.1",
     "expo-status-bar": "~57.0.1",
-    "expo-video": "~57.0.1",
     "lucide-react-native": "^1.25.0",
     "nativewind": "^5.0.0-preview.2",
     "react": "19.2.3",
@@ -37,6 +36,7 @@
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",
     "react-native-svg": "15.15.4",
+    "react-native-video": "^6.19.2",
     "react-native-webview": "^13.16.0",
     "react-native-worklets": "0.10.0",
     "react-native-youtube-iframe": "^2.4.1",

--- a/src/components/player/PlayerCore.tsx
+++ b/src/components/player/PlayerCore.tsx
@@ -1,13 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Pressable, StatusBar, StyleSheet } from 'react-native';
-import { useEvent, useEventListener } from 'expo';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Platform, Pressable, StatusBar, StyleSheet } from 'react-native';
 import { useIsFocused } from '@react-navigation/native';
-import {
-  isPictureInPictureSupported,
-  useVideoPlayer,
-  VideoView,
-  type VideoSource,
-} from 'expo-video';
+import Video, {
+  SelectedTrackType,
+  TextTrackType,
+  type BufferConfig,
+  type ISO639_1,
+  type OnLoadData,
+  type OnProgressData,
+  type OnPictureInPictureStatusChangedData,
+  type OnVideoErrorData,
+  type ReactVideoSource,
+  type SelectedTrack,
+  type TextTracks,
+  type VideoRef,
+} from 'react-native-video';
 import { Box } from '@/components/ui/box';
 import { Center } from '@/components/ui/center';
 import { Spinner } from '@/components/ui/spinner';
@@ -32,13 +39,13 @@ import {
 import { usePlaybackSettings } from '@/src/hooks/usePlaybackSettings';
 import { useSubtitles } from '@/src/hooks/useSubtitles';
 import { useSubtitleSettings } from '@/src/hooks/useSubtitleSettings';
-import { useVideoAspect } from '@/src/hooks/useVideoAspect';
+import { toResizeMode, useVideoAspect } from '@/src/hooks/useVideoAspect';
 import { useVideoQuality } from '@/src/hooks/useVideoQuality';
 import { fetchHlsVariants, type Variant } from '@/src/utils/hlsVariants';
 import type { Episode, MediaItem } from '@/src/types';
 
 interface PlayerCoreProps {
-  source: VideoSource;
+  source: ReactVideoSource;
   title: string;
   subtitle?: string;
   item: MediaItem;
@@ -50,9 +57,40 @@ interface PlayerCoreProps {
   onSelectEpisode?: (season: number, episode: Episode) => void;
 }
 
+/** Android has no PiP concept below API 26; iOS/tvOS support it wherever the
+ * OS itself does. There's no react-native-video free function for this,
+ * unlike expo-video's `isPictureInPictureSupported()`. */
+const isPipSupported = (): boolean =>
+  Platform.OS === 'ios' ||
+  (Platform.OS === 'android' && Number(Platform.Version) >= 26);
+
+/** Approximates expo-video's old `preferredForwardBufferDuration` (seconds)
+ * as ExoPlayer `bufferConfig` (ms-based) for Android. iOS uses the RNV
+ * top-level `preferredForwardBufferDuration` prop directly instead.
+ * `cacheSizeMB` approximates the old `useCaching: true` — expo-video's
+ * persistent cache only ever worked for HLS on Android anyway (iOS/
+ * AVFoundation never supported HLS caching), so this preserves that half
+ * of the behavior without needing a per-request opt-in. */
+const toAndroidBufferConfig = (forwardBufferSeconds: number): BufferConfig => {
+  const minBufferMs = Math.round(forwardBufferSeconds * 1000);
+  return {
+    minBufferMs,
+    maxBufferMs: Math.max(minBufferMs * 2, 50000),
+    bufferForPlaybackMs: 2500,
+    bufferForPlaybackAfterRebufferMs: 5000,
+    cacheSizeMB: 200,
+  };
+};
+
+type PlaybackStatus = 'loading' | 'ready' | 'error';
+
 /**
- * Owns the expo-video player instance and all playback UI. Created once with a
- * final, resolved source so the player is never recreated mid-playback.
+ * Owns the react-native-video player instance and all playback UI. Created
+ * once with a final, resolved source so the player is never recreated
+ * mid-playback — all later changes (quality swap, sidecar subtitle tracks
+ * arriving) go through the imperative `VideoRef.setSource()` call instead of
+ * changing the `source` prop, exactly mirroring how this used to work with
+ * expo-video's `player.replaceAsync()`.
  */
 export const PlayerCore = ({
   source,
@@ -83,11 +121,11 @@ export const PlayerCore = ({
   const [aspectOpen, setAspectOpen] = useState(false);
   const [pipActive, setPipActive] = useState(false);
   const { aspect, setAspect } = useVideoAspect();
-  const videoViewRef = useRef<VideoView>(null);
+  const videoRef = useRef<VideoRef>(null);
   const isTVShow = item.media_type === 'tv';
-  const pipSupported = isPictureInPictureSupported();
+  const pipSupported = isPipSupported();
   const enterPip = useCallback(() => {
-    videoViewRef.current?.startPictureInPicture();
+    videoRef.current?.enterPictureInPicture();
   }, []);
 
   // "Up Next" autoplay, gated on `onSelectEpisode` being provided (the
@@ -111,10 +149,9 @@ export const PlayerCore = ({
   // HLS-variant state. The master URI is captured once from the initial
   // `source` prop so quality swaps can always jump back to Auto.
   const sourceObj = typeof source === 'object' && source ? source : null;
-  const masterUri = sourceObj?.uri ?? null;
+  const masterUri = typeof sourceObj?.uri === 'string' ? sourceObj.uri : null;
   const isHls =
-    !!masterUri &&
-    (sourceObj?.contentType === 'hls' || masterUri.includes('.m3u8'));
+    !!masterUri && (sourceObj?.type === 'm3u8' || masterUri.includes('.m3u8'));
   const [variants, setVariants] = useState<Variant[]>([]);
   const [selectedVariantUri, setSelectedVariantUri] = useState<string | null>(
     null,
@@ -124,42 +161,96 @@ export const PlayerCore = ({
 
   // Settings > "Buffering" — user-editable forward-buffer window, defaulting
   // to a recommendation derived from the device's RAM (see
-  // `deviceRecommendations.ts`). Read once here: like `resumeFrom` and the
-  // other options below, this only applies at player-creation time (the
-  // player is never recreated mid-playback — see the class doc comment).
+  // `deviceRecommendations.ts`). Snapshotted once here: like `resumeFrom`
+  // and the other options below, this only applies at player-creation time
+  // (the player is never recreated mid-playback — see the class doc
+  // comment above).
   const { effectiveForwardBufferSeconds } = usePlaybackSettings();
+  const initialForwardBufferSecondsRef = useRef(effectiveForwardBufferSeconds);
+  const androidBufferConfigRef = useRef<BufferConfig | undefined>(
+    Platform.OS === 'android'
+      ? toAndroidBufferConfig(initialForwardBufferSecondsRef.current)
+      : undefined,
+  );
 
-  const player = useVideoPlayer(source, (p) => {
-    p.timeUpdateEventInterval = 0.5;
-    // Widen the forward-buffer window so stalls are less common on spotty
-    // networks. `minBufferForPlayback`/`prioritizeTimeOverSizeThreshold` are
-    // Android-only and no-op on iOS.
-    p.bufferOptions = {
-      preferredForwardBufferDuration: effectiveForwardBufferSeconds, // Android default 20, iOS default 0 = auto
-      minBufferForPlayback: 3,
-      prioritizeTimeOverSizeThreshold: true,
-    };
-    p.play();
+  const { settings: subtitleSettings } = useSubtitleSettings();
+  const nativeSubtitlesEnabled = subtitleSettings.renderMode === 'native';
+  // Sidecar (native OS) subtitle rendering via react-native-video's
+  // `source.textTracks` works on Android always, but NOT with HLS playlists
+  // on iOS (AVFoundation limitation — sidecar text tracks are only
+  // supported for individual files there, not HLS manifests). Since this
+  // app's scraped streams are virtually always HLS, that one
+  // platform+format combination falls back to the exact same
+  // component-mode rendering path below (Wyzie SRT fetched/parsed and
+  // drawn by `SubtitleOverlay`) instead of showing nothing, which is what
+  // "native" mode did before this migration (there was never anything
+  // embedded to select).
+  const useNativeSidecar =
+    nativeSubtitlesEnabled && !(Platform.OS === 'ios' && isHls);
+
+  // Wyzie search always runs now — it drives the picker list either way.
+  // Only the cue text fetch/parse is skipped when the sidecar path will
+  // hand the track's URL straight to the native player instead.
+  const {
+    tracks: wyzieTracks,
+    selectedId: wyzieSelectedId,
+    selectTrack: selectWyzieTrack,
+    cueAt,
+    loading: loadingWyzieTracks,
+  } = useSubtitles({
+    tmdbId: item.id,
+    season,
+    episode,
+    loadCues: !useNativeSidecar,
+    defaultLanguage: subtitleSettings.defaultLanguage,
   });
 
-  const { isPlaying } = useEvent(player, 'playingChange', {
-    isPlaying: player.playing,
-    oldIsPlaying: undefined,
-  });
-  const { currentTime, bufferedPosition } = useEvent(player, 'timeUpdate', {
-    currentTime: player.currentTime,
-    currentLiveTimestamp: null,
-    currentOffsetFromLive: null,
-    bufferedPosition: 0,
-  });
-  const { status, error } = useEvent(player, 'statusChange', {
-    status: player.status,
-  });
+  // The picker list is identical in both render modes now.
+  const subtitleTrackOptions = wyzieTracks.map((t) => ({
+    id: t.id,
+    label: `${t.display}${t.isHearingImpaired ? ' (CC)' : ''}`,
+  }));
+  const selectedWyzieTrack =
+    wyzieTracks.find((t) => t.id === wyzieSelectedId) ?? null;
+  const subtitlesActive = wyzieSelectedId != null;
 
-  const duration = player.duration ?? 0;
-  // `bufferedPosition` is -1 when unknown, 0 when not buffered past playhead.
+  // Sidecar text tracks handed straight to react-native-video: Wyzie serves
+  // `.srt` files directly from a hosted URL, so no fetch/parse is needed on
+  // our side at all for this path.
+  const sidecarTextTracks = useMemo<TextTracks | undefined>(() => {
+    if (!useNativeSidecar || !wyzieTracks.length) return undefined;
+    return wyzieTracks.map((t) => ({
+      title: t.display,
+      language: t.language as ISO639_1,
+      type: TextTrackType.SUBRIP,
+      uri: t.url,
+    }));
+  }, [useNativeSidecar, wyzieTracks]);
+
+  const selectedTextTrack: SelectedTrack | undefined = useNativeSidecar
+    ? selectedWyzieTrack
+      ? { type: SelectedTrackType.TITLE, value: selectedWyzieTrack.display }
+      : { type: SelectedTrackType.DISABLED }
+    : undefined;
+
+  // -------------------------------------------------------------------------
+  // Player state (mirrors what expo-video's `useEvent`/`player.*` used to
+  // expose, now derived from react-native-video's declarative props/events).
+  // -------------------------------------------------------------------------
+  const [paused, setPaused] = useState(false);
+  const isPlaying = !paused;
+  const [status, setStatus] = useState<PlaybackStatus>('loading');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [duration, setDuration] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [playableDuration, setPlayableDuration] = useState(0);
   const buffered =
-    duration > 0 && bufferedPosition > 0 ? bufferedPosition / duration : 0;
+    duration > 0 && playableDuration > 0 ? playableDuration / duration : 0;
+
+  // Component mode (or the iOS+HLS native fallback): drive `SubtitleOverlay`
+  // off the playhead ourselves.
+  const activeCue = useNativeSidecar ? null : cueAt(currentTime);
+
   const { visible, show, toggle } = useControlsVisibility(isPlaying);
 
   // Seconds left in the episode; `Infinity` until the player reports a real
@@ -193,10 +284,10 @@ export const PlayerCore = ({
   // that an advance decision is due — the actual decision is made by the
   // effect below, once `nextEpisodeLoading` confirms we actually know
   // whether there's a next episode (see comment on `pendingAdvance` above).
-  useEventListener(player, 'playToEnd', () => {
+  const onEnd = useCallback(() => {
     if (!autoplayNextEnabled) return;
     setPendingAdvance(true);
-  });
+  }, [autoplayNextEnabled]);
 
   // Resolve the pending advance: autoplay straight into the next episode
   // (unless the user already cancelled the Up Next card), or — only once
@@ -227,103 +318,6 @@ export const PlayerCore = ({
     return () => clearTimeout(timer);
   }, [seriesEnded, onBack]);
 
-  const { settings: subtitleSettings } = useSubtitleSettings();
-  const nativeSubtitlesEnabled = subtitleSettings.renderMode === 'native';
-
-  // "Component" mode: search Wyzie for external subtitle files by TMDB id,
-  // parse them, and drive `SubtitleOverlay` off the playhead ourselves.
-  // Skipped entirely (no network calls) while native mode is active.
-  const {
-    tracks: wyzieTracks,
-    selectedId: wyzieSelectedId,
-    selectTrack: selectWyzieTrack,
-    cueAt,
-    loading: loadingWyzieTracks,
-  } = useSubtitles({
-    tmdbId: item.id,
-    season,
-    episode,
-    enabled: !nativeSubtitlesEnabled,
-    defaultLanguage: subtitleSettings.defaultLanguage,
-  });
-
-  // "Native" mode: let expo-video render whatever subtitle tracks are
-  // embedded in the scraped stream itself via `player.subtitleTrack`. Only
-  // produces captions when the source actually contains tracks (see the
-  // `SubtitleRenderMode` doc comment in `useSubtitleSettings`).
-  const { availableSubtitleTracks } = useEvent(
-    player,
-    'availableSubtitleTracksChange',
-    { availableSubtitleTracks: player.availableSubtitleTracks },
-  );
-  const { subtitleTrack: nativeSubtitleTrack } = useEvent(
-    player,
-    'subtitleTrackChange',
-    { subtitleTrack: player.subtitleTrack },
-  );
-  // Guards against re-selecting after the user has made (or explicitly
-  // cleared to "Off") a choice. Naturally resets on remount, which is all
-  // that's needed since `PlayerCore` is remounted per-episode by its caller.
-  const didAutoSelectNativeRef = useRef(false);
-  useEffect(() => {
-    if (!nativeSubtitlesEnabled) return;
-    if (didAutoSelectNativeRef.current) return;
-    if (!subtitleSettings.defaultLanguage) return;
-    if (!availableSubtitleTracks.length) return;
-    const match = availableSubtitleTracks.find(
-      (t) => t.language === subtitleSettings.defaultLanguage,
-    );
-    if (match) {
-      didAutoSelectNativeRef.current = true;
-      player.subtitleTrack = match;
-    }
-  }, [
-    nativeSubtitlesEnabled,
-    availableSubtitleTracks,
-    subtitleSettings.defaultLanguage,
-    player,
-  ]);
-
-  const selectNativeTrack = useCallback(
-    (id: string | null) => {
-      didAutoSelectNativeRef.current = true;
-      if (id == null) {
-        player.subtitleTrack = null;
-        return;
-      }
-      const idx = Number(id);
-      player.subtitleTrack = availableSubtitleTracks[idx] ?? null;
-    },
-    [availableSubtitleTracks, player],
-  );
-
-  const subtitleTrackOptions = nativeSubtitlesEnabled
-    ? availableSubtitleTracks.map((t, i) => ({
-        id: String(i),
-        label: t.label || t.name || t.language,
-      }))
-    : wyzieTracks.map((t) => ({
-        id: t.id,
-        label: `${t.display}${t.isHearingImpaired ? ' (CC)' : ''}`,
-      }));
-  const selectedSubtitleId = nativeSubtitlesEnabled
-    ? nativeSubtitleTrack
-      ? String(
-          availableSubtitleTracks.findIndex(
-            (t) =>
-              t.language === nativeSubtitleTrack.language &&
-              t.label === nativeSubtitleTrack.label &&
-              t.name === nativeSubtitleTrack.name,
-          ),
-        )
-      : null
-    : wyzieSelectedId;
-  const subtitlesActive = nativeSubtitlesEnabled
-    ? nativeSubtitleTrack != null
-    : wyzieSelectedId != null;
-
-  const activeCue = nativeSubtitlesEnabled ? null : cueAt(currentTime);
-
   // Mirror the latest position/duration into refs for safe cleanup reads.
   useEffect(() => {
     currentTimeRef.current = currentTime;
@@ -346,23 +340,45 @@ export const PlayerCore = ({
     };
   }, [isHls, masterUri, sourceObj?.headers]);
 
+  // -------------------------------------------------------------------------
+  // Source construction. The `source` PROP given to `<Video>` is built ONCE
+  // at mount (`initialSource` below) and never changed afterwards — quality
+  // swaps and the sidecar text-track list arriving both go through the
+  // imperative `videoRef.current.setSource()` instead (see `swapToUri` and
+  // the sidecar-apply effect), each one folding in whatever the OTHER
+  // dimension's latest value is via these refs, so neither clobbers the
+  // other.
+  // -------------------------------------------------------------------------
+  const activeUriRef = useRef<string | null>(masterUri);
+  const activeTextTracksRef = useRef<TextTracks | undefined>(undefined);
+  const pendingSeekRef = useRef<number | null>(null);
+
+  const buildSource = useCallback(
+    (uri: string, textTracks: TextTracks | undefined): ReactVideoSource => ({
+      ...(sourceObj ?? {}),
+      uri,
+      bufferConfig: androidBufferConfigRef.current,
+      textTracks,
+    }),
+    [sourceObj],
+  );
+
+  const [initialSource] = useState<ReactVideoSource>(() =>
+    buildSource(masterUri ?? '', undefined),
+  );
+
   // Swap the current stream URI while preserving the play head. Called by
   // both the initial-preference effect and the user-facing quality picker.
   const swapToUri = useCallback(
-    async (nextUri: string) => {
+    (nextUri: string) => {
       if (!sourceObj) return;
-      const resumeAt = currentTimeRef.current;
-      const wasPlaying = player.playing;
-      try {
-        await player.replaceAsync({ ...sourceObj, uri: nextUri });
-        if (resumeAt > 0) player.currentTime = resumeAt;
-        if (wasPlaying) player.play();
-      } catch {
-        // If replaceAsync fails, the previous source stays loaded; nothing to
-        // roll back on our side.
-      }
+      pendingSeekRef.current = currentTimeRef.current;
+      activeUriRef.current = nextUri;
+      videoRef.current?.setSource(
+        buildSource(nextUri, activeTextTracksRef.current),
+      );
     },
-    [player, sourceObj],
+    [sourceObj, buildSource],
   );
 
   // Apply the persisted preferred quality once variants land. `pickInitial`
@@ -374,7 +390,7 @@ export const PlayerCore = ({
     didApplyInitialQualityRef.current = true;
     if (!initial) return;
     setSelectedVariantUri(initial.uri);
-    void swapToUri(initial.uri);
+    swapToUri(initial.uri);
   }, [variants, pickInitialVariant, swapToUri]);
 
   const onSelectQuality = useCallback(
@@ -382,23 +398,68 @@ export const PlayerCore = ({
       if (!masterUri) return;
       const nextUri = variant?.uri ?? masterUri;
       setSelectedVariantUri(variant?.uri ?? null);
-      void swapToUri(nextUri);
+      swapToUri(nextUri);
     },
     [masterUri, swapToUri],
   );
 
-  // Resume from saved position once ready.
-  useEventListener(player, 'statusChange', ({ status: next }) => {
-    if (
-      next === 'readyToPlay' &&
-      !didResumeRef.current &&
-      resumeFrom != null &&
-      resumeFrom > 0
-    ) {
-      didResumeRef.current = true;
-      player.currentTime = resumeFrom;
+  // Apply the sidecar text-track list once Wyzie's search resolves (it
+  // arrives shortly after mount, asynchronously). Applied only once per
+  // mount/track-list — if the user later changes render mode there's no
+  // live re-apply, matching how quality/aspect settings already only take
+  // effect at player-creation time.
+  const didApplySidecarTracksRef = useRef(false);
+  useEffect(() => {
+    if (!useNativeSidecar) return;
+    if (didApplySidecarTracksRef.current) return;
+    if (!sidecarTextTracks || !sidecarTextTracks.length) return;
+    didApplySidecarTracksRef.current = true;
+    activeTextTracksRef.current = sidecarTextTracks;
+    if (activeUriRef.current) {
+      videoRef.current?.setSource(
+        buildSource(activeUriRef.current, sidecarTextTracks),
+      );
     }
-  });
+  }, [useNativeSidecar, sidecarTextTracks, buildSource]);
+
+  const onLoad = useCallback(
+    (e: OnLoadData) => {
+      setStatus('ready');
+      setDuration(e.duration);
+      if (pendingSeekRef.current != null) {
+        const seekTo = pendingSeekRef.current;
+        pendingSeekRef.current = null;
+        videoRef.current?.seek(seekTo);
+      } else if (!didResumeRef.current && resumeFrom != null && resumeFrom > 0) {
+        didResumeRef.current = true;
+        videoRef.current?.seek(resumeFrom);
+      }
+    },
+    [resumeFrom],
+  );
+
+  const onError = useCallback((e: OnVideoErrorData) => {
+    setStatus('error');
+    const err = e.error;
+    setErrorMessage(
+      err?.localizedDescription ||
+        err?.errorString ||
+        err?.error ||
+        'The source could not be loaded.',
+    );
+  }, []);
+
+  const onProgress = useCallback((e: OnProgressData) => {
+    setCurrentTime(e.currentTime);
+    setPlayableDuration(e.playableDuration);
+  }, []);
+
+  const onPipStatusChanged = useCallback(
+    (e: OnPictureInPictureStatusChangedData) => {
+      setPipActive(e.isActive);
+    },
+    [],
+  );
 
   // Persist continue-watching progress. Reads ONLY from refs.
   const saveProgress = useCallback(() => {
@@ -427,24 +488,23 @@ export const PlayerCore = ({
   }, [saveProgress]);
 
   const togglePlay = useCallback(() => {
-    if (player.playing) player.pause();
-    else player.play();
+    setPaused((p) => !p);
     show();
-  }, [player, show]);
+  }, [show]);
 
   const seekBy = useCallback(
     (seconds: number) => {
-      player.seekBy(seconds);
+      videoRef.current?.seek(currentTimeRef.current + seconds);
       show();
     },
-    [player, show],
+    [show],
   );
 
   const seekToFraction = useCallback(
     (value: number) => {
-      if (duration > 0) player.currentTime = value * duration;
+      if (duration > 0) videoRef.current?.seek(value * duration);
     },
-    [player, duration],
+    [duration],
   );
 
   // On Android TV, `TVEventHandler`'s raw remote-event feed and the native
@@ -482,17 +542,28 @@ export const PlayerCore = ({
     <Box className="flex-1 bg-black">
       <StatusBar hidden />
       {isFocused && (
-        <VideoView
-          ref={videoViewRef}
-          player={player}
+        <Video
+          ref={videoRef}
+          source={initialSource}
           style={StyleSheet.absoluteFill}
-          nativeControls={false}
-          contentFit={aspect}
+          controls={false}
+          resizeMode={toResizeMode(aspect)}
           pointerEvents="none"
-          allowsPictureInPicture
-          startsPictureInPictureAutomatically={!!source}
-          onPictureInPictureStart={() => setPipActive(true)}
-          onPictureInPictureStop={() => setPipActive(false)}
+          paused={paused}
+          progressUpdateInterval={500}
+          preferredForwardBufferDuration={
+            Platform.OS === 'ios'
+              ? initialForwardBufferSecondsRef.current
+              : undefined
+          }
+          selectedTextTrack={selectedTextTrack}
+          enterPictureInPictureOnLeave
+          onLoadStart={() => setStatus('loading')}
+          onLoad={onLoad}
+          onError={onError}
+          onEnd={onEnd}
+          onProgress={onProgress}
+          onPictureInPictureStatusChanged={onPipStatusChanged}
         />
       )}
 
@@ -512,7 +583,7 @@ export const PlayerCore = ({
             Unable to play this video
           </Text>
           <Text size="sm" className="mt-2 text-center text-muted-foreground">
-            {error?.message ?? 'The source could not be loaded.'}
+            {errorMessage ?? 'The source could not be loaded.'}
           </Text>
         </Center>
       )}
@@ -611,14 +682,10 @@ export const PlayerCore = ({
       <SubtitleTrackSheet
         visible={sheetOpen}
         tracks={subtitleTrackOptions}
-        selectedId={selectedSubtitleId}
-        loading={!nativeSubtitlesEnabled && loadingWyzieTracks}
-        emptyLabel={
-          nativeSubtitlesEnabled
-            ? "This stream doesn't include any built-in subtitle tracks."
-            : 'No subtitles found for this title.'
-        }
-        onSelect={nativeSubtitlesEnabled ? selectNativeTrack : selectWyzieTrack}
+        selectedId={wyzieSelectedId}
+        loading={loadingWyzieTracks}
+        emptyLabel="No subtitles found for this title."
+        onSelect={selectWyzieTrack}
         onClose={() => setSheetOpen(false)}
       />
 

--- a/src/components/player/SubtitleOverlay.tsx
+++ b/src/components/player/SubtitleOverlay.tsx
@@ -12,9 +12,9 @@ interface SubtitleOverlayProps {
    *
    * NOTE: On iOS, AVKit's PiP window shows only the native video surface, so
    * this React Native overlay cannot render inside the PiP mini window. On
-   * Android, expo-video enters activity-level PiP and this overlay is drawn
-   * scaled down inside the mini window (readability depends on the user's
-   * fontSize setting).
+   * Android, react-native-video enters activity-level PiP and this overlay
+   * is drawn scaled down inside the mini window (readability depends on the
+   * user's fontSize setting).
    */
   pipActive?: boolean;
 }

--- a/src/components/player/SubtitleTrackSheet.tsx
+++ b/src/components/player/SubtitleTrackSheet.tsx
@@ -4,8 +4,9 @@ import { Text } from '@/components/ui/text';
 import { Heading } from '@/components/ui/heading';
 import { VStack } from '@/components/ui/vstack';
 
-/** A single selectable entry, decoupled from where the track actually came
- * from (a Wyzie search result vs. a native `expo-video` `SubtitleTrack`). */
+/** A single selectable entry, decoupled from how it's ultimately rendered
+ * (drawn by our own `SubtitleOverlay` vs. handed to react-native-video as a
+ * native sidecar text track — see `useSubtitleSettings`'s `renderMode`). */
 export interface SubtitleTrackOption {
   id: string;
   label: string;

--- a/src/hooks/useSubtitleSettings.tsx
+++ b/src/hooks/useSubtitleSettings.tsx
@@ -16,13 +16,15 @@ const STORAGE_KEY = 'flick.subtitleSettings';
  * parsed, and drawn by our own `SubtitleOverlay` — this works the same way
  * regardless of what a given scraped stream actually contains.
  *
- * `'native'`: subtitles are handled entirely by `expo-video` via
- * `player.subtitleTrack` / `player.availableSubtitleTracks` (see the
- * `SubtitleTrack` type). This only shows anything when the stream itself
- * embeds subtitle tracks (for example an HLS rendition with
- * `TYPE=SUBTITLES`) — most scraped movie/TV embeds don't include any, so
- * this is best thought of as "prefer the device/stream's own captions when
- * present" rather than a guaranteed alternative.
+ * `'native'`: the same Wyzie-searched subtitle tracks are handed to
+ * `react-native-video` as a sidecar `source.textTracks` entry (Wyzie serves
+ * `.srt` directly, so no extra parsing is needed) and rendered by the OS's
+ * own caption renderer via `selectedTextTrack`, instead of our
+ * `SubtitleOverlay`. This works on Android for any stream, but NOT on iOS
+ * when the source is HLS (AVFoundation only supports sidecar text tracks
+ * for individual files, not `.m3u8` playlists) — since scraped streams here
+ * are virtually always HLS, iOS transparently falls back to the
+ * `'component'` rendering path in that case (see `PlayerCore.tsx`).
  */
 export type SubtitleRenderMode = 'component' | 'native';
 

--- a/src/hooks/useSubtitles.ts
+++ b/src/hooks/useSubtitles.ts
@@ -11,6 +11,15 @@ interface UseSubtitlesArgs {
   season?: number;
   episode?: number;
   enabled?: boolean;
+  /**
+   * Whether to download + parse the selected track's `.srt`/`.vtt` text into
+   * `cues` for `SubtitleOverlay` to render. Defaults to `true`. Callers that
+   * hand the track's `url` straight to a native sidecar text track instead
+   * (react-native-video's `source.textTracks`) can set this to `false` to
+   * skip the extra network fetch — the track *search* above still needs to
+   * run either way, since it's also how the sidecar list gets built.
+   */
+  loadCues?: boolean;
   /** ISO 639-1 code; auto-selects a matching track when tracks load. */
   defaultLanguage?: string;
 }
@@ -22,6 +31,7 @@ export const useSubtitles = ({
   season,
   episode,
   enabled = true,
+  loadCues = true,
   defaultLanguage,
 }: UseSubtitlesArgs) => {
   const [tracks, setTracks] = useState<WyzieSubtitle[]>([]);
@@ -91,7 +101,7 @@ export const useSubtitles = ({
   }, [tracks, defaultLanguage, selectedId]);
 
   useEffect(() => {
-    if (!selectedId) {
+    if (!loadCues || !selectedId) {
       setCues([]);
       return;
     }
@@ -115,7 +125,7 @@ export const useSubtitles = ({
     return () => {
       cancelled = true;
     };
-  }, [selectedId, tracks]);
+  }, [loadCues, selectedId, tracks]);
 
   const selectTrack = useCallback((id: string | null) => {
     // Any manual selection (including explicit "Off") disables auto-select.

--- a/src/hooks/useVideoAspect.tsx
+++ b/src/hooks/useVideoAspect.tsx
@@ -8,18 +8,26 @@ import {
   type ReactNode,
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import type { VideoContentFit } from 'expo-video';
+import type { EnumValues, ResizeMode as VideoResizeMode } from 'react-native-video';
 
 const STORAGE_KEY = 'flick.videoAspect';
 
 /**
- * Mirrors expo-video's `VideoContentFit`:
+ * App-level aspect abstraction (kept simple/stable for Settings UI), mapped
+ * to react-native-video's `resizeMode` at the `<Video>` call site via
+ * `toResizeMode` below:
  *
  * - `contain` (default) - keep aspect ratio, letterbox as needed.
  * - `cover` - keep aspect ratio, crop to fill the screen.
  * - `fill` - stretch to fill the screen (may distort).
  */
-export type VideoAspect = VideoContentFit;
+export type VideoAspect = 'contain' | 'cover' | 'fill';
+
+/** Maps our `VideoAspect` to react-native-video's `resizeMode` prop values
+ * (`'none' | 'contain' | 'cover' | 'stretch'`) — RNV has no `fill`, its
+ * equivalent non-uniform-scale mode is `stretch`. */
+export const toResizeMode = (aspect: VideoAspect): EnumValues<VideoResizeMode> =>
+  aspect === 'fill' ? 'stretch' : aspect;
 
 export interface VideoAspectOption {
   value: VideoAspect;

--- a/src/screens/CreditsScreen.tsx
+++ b/src/screens/CreditsScreen.tsx
@@ -36,8 +36,14 @@ const CREDITS: Credit[] = [
   {
     name: 'Expo',
     description:
-      'Built with Expo SDK 57 on top of React Native. expo-video powers playback, expo-navigation-bar keeps the player immersive, expo-keep-awake holds the wake lock during playback.',
+      'Built with Expo SDK 57 on top of React Native. expo-navigation-bar keeps the player immersive, expo-keep-awake holds the wake lock during playback.',
     url: 'https://expo.dev',
+  },
+  {
+    name: 'react-native-video',
+    description:
+      "Powers all video playback, including quality switching, Picture-in-Picture, and native subtitle tracks. Maintained by TheWidlarzGroup and the react-native-video community.",
+    url: 'https://github.com/TheWidlarzGroup/react-native-video',
   },
   {
     name: 'gluestack-ui v5',

--- a/src/screens/PlayerScreen.tsx
+++ b/src/screens/PlayerScreen.tsx
@@ -3,7 +3,7 @@ import { Platform, Pressable, StatusBar, StyleSheet } from 'react-native';
 import { ArrowLeft, VideoOff } from 'lucide-react-native';
 import { useKeepAwake } from 'expo-keep-awake';
 import { NavigationBar } from 'expo-navigation-bar';
-import type { VideoSource } from 'expo-video';
+import type { ReactVideoSource } from 'react-native-video';
 import { Box } from '@/components/ui/box';
 import { Center } from '@/components/ui/center';
 import { Icon } from '@/components/ui/icon';
@@ -64,7 +64,7 @@ export const PlayerScreen = ({
   const [episode, setEpisode] = useState<number | undefined>(initialEpisode);
   const [title, setTitle] = useState(initialTitle);
   const [subtitle, setSubtitle] = useState<string | undefined>(initialSubtitle);
-  const [source, setSource] = useState<VideoSource | null>(null);
+  const [source, setSource] = useState<ReactVideoSource | null>(null);
   /**
    * Set to `true` when the WebViewScraper gives up. Renders a "No video
    * available" UI instead of silently falling back to a sample URL.
@@ -99,7 +99,7 @@ export const PlayerScreen = ({
     };
   }, []);
 
-  const finish = useCallback((s: VideoSource) => {
+  const finish = useCallback((s: ReactVideoSource) => {
     if (resolvedRef.current) return;
     resolvedRef.current = true;
     setSource(s);
@@ -110,7 +110,7 @@ export const PlayerScreen = ({
   // Downloads screen), otherwise best-effort lookup by the current item +
   // season/episode. This lets Home "Continue Watching", Detail Play, and
   // Downloads all seamlessly reuse a completed download.
-  const localForCurrent = useMemo<VideoSource | null>(() => {
+  const localForCurrent = useMemo<ReactVideoSource | null>(() => {
     const id = localSourceId ?? getJobFor(item, season, episode)?.id;
     if (!id) return null;
     return getLocalSource(id) ?? null;
@@ -121,9 +121,9 @@ export const PlayerScreen = ({
   const toastedKeyRef = useRef<string | null>(null);
 
   // Playing back a downloaded copy: short-circuit the scraper entirely and
-  // feed the local URI straight into expo-video. We also surface a lightweight
-  // "playing offline copy" toast the first time this happens per episode so
-  // the user knows we're saving data.
+  // feed the local URI straight into react-native-video. We also surface a
+  // lightweight "playing offline copy" toast the first time this happens
+  // per episode so the user knows we're saving data.
   //
   // The `resolvedRef` guard matters: if the user was ALREADY streaming and a
   // background download for this same episode finished mid-playback, we
@@ -155,19 +155,22 @@ export const PlayerScreen = ({
       // Debug mode: a stream request was intercepted, confirming the page
       // itself is now actually playing the video — but deliberately don't
       // hand off to the native `PlayerCore`. Some streams that fail (DRM,
-      // header/cookie quirks, decoder support) in expo-video play back fine
-      // directly inside the browser context that resolved them, so staying
-      // on the WebView here doubles as a way to actually watch those.
+      // header/cookie quirks, decoder support) in react-native-video play
+      // back fine directly inside the browser context that resolved them,
+      // so staying on the WebView here doubles as a way to actually watch
+      // those.
       if (scraperDebugEnabled) {
         setDebugStreamFound(true);
         return;
       }
       finish({
         uri: url,
-        contentType: url.includes('.m3u8') ? 'hls' : 'auto',
-        // Persistent LRU cache: Android caches HLS/MP4/WebM, iOS caches
-        // MP4/WebM only (HLS caching is unsupported by AVFoundation).
-        useCaching: true,
+        // Explicit MIME hint for HLS; react-native-video otherwise infers
+        // from the URL/response, matching expo-video's 'auto' for anything
+        // else. Persistent caching is handled separately, per-platform, via
+        // `source.bufferConfig.cacheSizeMB` inside `PlayerCore` (Android
+        // only — iOS/AVFoundation never cached HLS anyway).
+        type: url.includes('.m3u8') ? 'm3u8' : undefined,
         // Default the request origin to the selected server, which many
         // stream hosts require (403 otherwise).
         headers: {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -21,6 +21,7 @@ import { HStack } from '@/components/ui/hstack';
 import { Heading } from '@/components/ui/heading';
 import { Icon } from '@/components/ui/icon';
 import { Text } from '@/components/ui/text';
+import { ScrollView } from '@/components/ui/scroll-view';
 import { Focusable } from '@/src/components/Focusable';
 import { useServers } from '@/src/hooks/useServers';
 import { useSubtitleSettings } from '@/src/hooks/useSubtitleSettings';
@@ -67,69 +68,74 @@ export const SettingsScreen = () => {
         Settings
       </Heading>
 
-      <VStack space="sm" className="px-4">
-        <MenuRow
-          icon={ServerIcon}
-          label="Playback server"
-          value={activeServer.name}
-          onPress={() => navigation.navigate('ServerSettings')}
-        />
-        <MenuRow
-          icon={MonitorPlay}
-          label="Video quality"
-          value={`Preferred: ${videoQualityLabel}`}
-          onPress={() => navigation.navigate('VideoQualitySettings')}
-        />
-        <MenuRow
-          icon={Ratio}
-          label="Video aspect"
-          value={videoAspectLabel}
-          onPress={() => navigation.navigate('VideoAspectSettings')}
-        />
-        <MenuRow
-          icon={Captions}
-          label="Subtitles"
-          value={`Default: ${subtitleLangLabel}`}
-          onPress={() => navigation.navigate('SubtitleSettings')}
-        />
-        <MenuRow
-          icon={Gauge}
-          label="Buffering"
-          value={`${effectiveForwardBufferSeconds}s${forwardBufferSeconds == null ? ' · Auto' : ''} · ${formatMemoryGb(deviceTotalMemory)} RAM`}
-          onPress={() => navigation.navigate('PlaybackPerformance')}
-        />
-        <MenuRow
-          icon={CheckCircle2}
-          label="Finished movies"
-          value={`${finishedMovies.length} completed`}
-          onPress={() => navigation.navigate('FinishedMovies')}
-        />
-        <MenuRow
-          icon={Download}
-          label="Check for updates"
-          value={`Current version: v${updateService.getCurrentVersion()}`}
-          onPress={() => setUpdaterOpen(true)}
-        />
-        <MenuRow
-          icon={Info}
-          label="Disclaimer"
-          value="About content sources & third-party servers"
-          onPress={() => navigation.navigate('Disclaimer')}
-        />
-        <MenuRow
-          icon={Heart}
-          label="Credits"
-          value="Attributions for TMDB, Wyzie & more"
-          onPress={() => navigation.navigate('Credits')}
-        />
-        <SwitchRow
-          icon={Bug}
-          label="Debug video player"
-          hint="Show the stream-finder webpage, never time out, and play video directly in it instead of handing off to the built-in player, 3rd party players may have ads"
-          value={scraperDebugEnabled}
-          onToggle={setScraperDebugEnabled}
-        />
-      </VStack>
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
+      >
+        <VStack space="sm" className="px-4">
+          <MenuRow
+            icon={ServerIcon}
+            label="Playback server"
+            value={activeServer.name}
+            onPress={() => navigation.navigate('ServerSettings')}
+          />
+          <MenuRow
+            icon={MonitorPlay}
+            label="Video quality"
+            value={`Preferred: ${videoQualityLabel}`}
+            onPress={() => navigation.navigate('VideoQualitySettings')}
+          />
+          <MenuRow
+            icon={Ratio}
+            label="Video aspect"
+            value={videoAspectLabel}
+            onPress={() => navigation.navigate('VideoAspectSettings')}
+          />
+          <MenuRow
+            icon={Captions}
+            label="Subtitles"
+            value={`Default: ${subtitleLangLabel}`}
+            onPress={() => navigation.navigate('SubtitleSettings')}
+          />
+          <MenuRow
+            icon={Gauge}
+            label="Buffering"
+            value={`${effectiveForwardBufferSeconds}s${forwardBufferSeconds == null ? ' · Auto' : ''} · ${formatMemoryGb(deviceTotalMemory)} RAM`}
+            onPress={() => navigation.navigate('PlaybackPerformance')}
+          />
+          <MenuRow
+            icon={CheckCircle2}
+            label="Finished movies"
+            value={`${finishedMovies.length} completed`}
+            onPress={() => navigation.navigate('FinishedMovies')}
+          />
+          <MenuRow
+            icon={Download}
+            label="Check for updates"
+            value={`Current version: v${updateService.getCurrentVersion()}`}
+            onPress={() => setUpdaterOpen(true)}
+          />
+          <MenuRow
+            icon={Info}
+            label="Disclaimer"
+            value="About content sources & third-party servers"
+            onPress={() => navigation.navigate('Disclaimer')}
+          />
+          <MenuRow
+            icon={Heart}
+            label="Credits"
+            value="Attributions for TMDB, Wyzie & more"
+            onPress={() => navigation.navigate('Credits')}
+          />
+          <SwitchRow
+            icon={Bug}
+            label="Debug video player"
+            hint="Show the stream-finder webpage, never time out, and play video directly in it instead of handing off to the built-in player, 3rd party players may have ads"
+            value={scraperDebugEnabled}
+            onToggle={setScraperDebugEnabled}
+          />
+        </VStack>
+      </ScrollView>
 
       <UpdateModal
         visible={updaterOpen}

--- a/src/screens/SubtitleSettingsScreen.tsx
+++ b/src/screens/SubtitleSettingsScreen.tsx
@@ -35,7 +35,7 @@ const RENDER_MODE_OPTIONS: {
   {
     value: 'native',
     label: 'Native (device)',
-    hint: "Uses the video's own built-in subtitle tracks, if the stream provides any — most scraped streams don't.",
+    hint: "Uses your device's own caption renderer instead of Flick's. Works for any stream on Android; on iOS it only works for non-HLS video, so HLS streams there (almost all of them) automatically use App captions instead.",
   },
 ];
 

--- a/src/services/DownloadService.ts
+++ b/src/services/DownloadService.ts
@@ -7,7 +7,7 @@ import {
   setConfig,
   type DownloadTask,
 } from '@kesha-antonov/react-native-background-downloader';
-import type { VideoSource } from 'expo-video';
+import type { ReactVideoSource } from 'react-native-video';
 import type { MediaItem } from '@/src/types';
 import { originOf } from '@/src/utils/streamUrl';
 import {
@@ -300,12 +300,12 @@ class DownloadServiceImpl {
     );
   }
 
-  getLocalSource(id: string): VideoSource | null {
+  getLocalSource(id: string): ReactVideoSource | null {
     const job = this.jobs.get(id);
     if (!job || job.status !== 'completed' || !job.localUri) return null;
     return {
       uri: job.localUri,
-      contentType: job.kind === 'hls' ? 'hls' : 'auto',
+      type: job.kind === 'hls' ? 'm3u8' : undefined,
     };
   }
 

--- a/src/utils/deviceRecommendations.ts
+++ b/src/utils/deviceRecommendations.ts
@@ -10,9 +10,10 @@ export const FORWARD_BUFFER_STEP_SECONDS = 10;
 const DEFAULT_FORWARD_BUFFER_SECONDS = 30;
 
 /**
- * Recommends a `preferredForwardBufferDuration` (seconds of media to buffer
- * ahead of the playhead — see `expo-video`'s `BufferOptions`) based on the
- * device's total RAM.
+ * Recommends a forward-buffer window (seconds of media to buffer ahead of
+ * the playhead — fed into react-native-video as `preferredForwardBufferDuration`
+ * on iOS and `source.bufferConfig` on Android) based on the device's total
+ * RAM.
  *
  * A larger read-ahead window means fewer stalls on flaky connections, but
  * costs more resident memory per player instance (buffered segments are kept

--- a/src/utils/hlsVariants.ts
+++ b/src/utils/hlsVariants.ts
@@ -1,10 +1,11 @@
 /**
  * HLS master-playlist parsing utilities.
  *
- * `expo-video` exposes `videoTrack` as read-only, so we drive the "select
- * a resolution" feature by parsing the master `.m3u8`, listing its variants,
- * and swapping `VideoSource.uri` to a variant's child playlist via
- * `player.replaceAsync(...)`.
+ * react-native-video exposes `selectedVideoTrack` for ABR-managed
+ * resolution hints on Android only, so — for cross-platform parity — we
+ * still drive the "select a resolution" feature ourselves by parsing the
+ * master `.m3u8`, listing its variants, and swapping the source to a
+ * variant's child playlist via `VideoRef.setSource(...)`.
  *
  * A master playlist looks like:
  *


### PR DESCRIPTION
- Replaced expo-video with react-native-video to support advanced playback functionalities including Picture-in-Picture and native subtitle tracks.
- Updated video source handling and buffering configurations to align with react-native-video's API.
- Enhanced subtitle rendering options and improved user experience with subtitle settings.
- Bumped package version to 2.1.1 in package.json.